### PR TITLE
Update SerialApp.cpp

### DIFF
--- a/App/SerialApp.cpp
+++ b/App/SerialApp.cpp
@@ -355,7 +355,7 @@ void SerialApp::close()
 void SerialApp::send()
 {
     char *data;
-    QByteArray dataArray = this->sendEdit->text().toAscii();
+    QByteArray dataArray = this->sendEdit->text().toLatin1();
     data = dataArray.data();
     port.writeToPort(data,dataArray.size());
     this->sendEdit->clear();


### PR DESCRIPTION
toAscii() has been deprecated since Qt5 which causes build failure while compiling with Qt5.
Usage of toLatin1() is suggested instead of using toAscii().
