### PR TITLE
Fix serial port names for UNIX (typo)

### DIFF
--- a/App/SerialApp.cpp
+++ b/App/SerialApp.cpp
@@ -16,7 +16,7 @@ SerialPort SerialApp::port(0);
 void SerialApp::refreshDevices()
 {
     QStringList deviceList;
-#ifdef Q_OS__UNIX
+#ifdef Q_OS_UNIX
     QDir dir("/dev/");
     QStringList filters;
     filters  << "ttyUSB*" << "ttyS*";


### PR DESCRIPTION
Q_OS__UNIX -> Q_OS_UNIX (remove double underscore)
